### PR TITLE
이전 거래내역 검색 속도 향상을 위한 구조적 개선

### DIFF
--- a/back/src/application/interface/LocationFormRepository.js
+++ b/back/src/application/interface/LocationFormRepository.js
@@ -29,12 +29,15 @@ module.exports = class {
         throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
     }
 
-    async findRecentlyDeals(coordinate, ssg_cd) {
-        // coordinate = {min_x,min_y,max_x,max_y}
+    async findRecentlyDealsId(year, month, ssg_cd) {
         throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
     }
 
-    async findProviousOfRecentlyDeals(coordinate, ssg_cd) {
+    async findDealsOfId(idList, ssg_cd) {
+        throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
+    }
+
+    async findDealsOfIdCoordinate(idList, coordinate, ssg_cd) {
         // coordinate = {min_x,min_y,max_x,max_y}
         throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
     }

--- a/back/src/application/interface/LocationFormRepository.js
+++ b/back/src/application/interface/LocationFormRepository.js
@@ -17,6 +17,14 @@ module.exports = class {
         throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
     }
 
+    async findDealsYM(year, month, name, sgg_cd) {
+        throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
+    }
+
+    async findProviousDealOne(deal, sgg_cd) {
+        throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
+    }
+
     async findRecentlyDealOnType(hous_type, sgg_cd) {
         throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
     }

--- a/back/src/application/service/dealsUpdate.js
+++ b/back/src/application/service/dealsUpdate.js
@@ -74,8 +74,10 @@ module.exports = class dealUpdate {
 
                 for (const data of res.data) {
                     const res = await this.findCoordinate(await this.addressParse(name, data));
-
-                    deals.push(new DealDomain(data['법정동'], (data['단지'] || data['연립다세대'] || data['아파트']), data['지번'], parseInt(data['거래금액'].replace(/,/g, '')), data['건축년도'], data['년'], data['월'], data['일'], data['전용면적'], data['층'], name, (data['해제여부'] === 'O'), data['해제사유발생일'], data['거래유형'], res.data.x, res.data.y));
+                    const deal = new DealDomain(data['법정동'], (data['단지'] || data['연립다세대'] || data['아파트']), data['지번'], parseInt(data['거래금액'].replace(/,/g, '')), data['건축년도'], data['년'], data['월'], data['일'], data['전용면적'], data['층'], name, (data['해제여부'] === 'O'), data['해제사유발생일'], data['거래유형'], res.data.x, res.data.y);
+                    const provious = await this.LocationForm.findProviousDealOne(deal, sgg_cd);
+                    deal.provious = (provious ? provious.id : null);
+                    deals.push(deal);
                 }
                 await this.dataInsertOrSwap(sgg_cd, name, start, check, deals);
                 logger.info(`'${sgg_cd}${name}': ${start.Year}.${start.Month} 완료`);
@@ -170,11 +172,6 @@ module.exports = class dealUpdate {
             const LocationForm = this.LocationForm;
             try {
                 if (check.Year > start.Year || (check.Year === start.Year && check.Month >= start.Month)) {
-                    // await LocationForm.deleteDeals({
-                    //         house_type:name,
-                    //         Year:start.Year,
-                    //         Month:start.Month,
-                    // },sgg_cd)
                     await LocationForm.deleteDeals(name, start.Year, start.Month, sgg_cd)
                         .then(async () => {
                             await LocationForm.bulkCreate(deals, sgg_cd);

--- a/back/src/application/service/locationForm.js
+++ b/back/src/application/service/locationForm.js
@@ -57,8 +57,10 @@ module.exports = class {
             const min_x = await this.repository.findMinOne('x', sgg_cd);
             const max_y = await this.repository.findMaxOne('y', sgg_cd);
             const min_y = await this.repository.findMinOne('y', sgg_cd);
-
-            return new CoordinateDomain(min_x.x, max_x.x, min_y.y, max_y.y);
+            if (max_x) {
+                return new CoordinateDomain(min_x.x, max_x.x, min_y.y, max_y.y);
+            }
+            return new CoordinateDomain(min_x, max_x, min_y, max_y);
         } catch (error) {
             return RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.DB_FIND_ERROR_NAME(sgg_cd));
         }

--- a/back/src/application/service/locationForm.js
+++ b/back/src/application/service/locationForm.js
@@ -25,20 +25,27 @@ module.exports = class {
     }
 
     async findProviousOfRecentlyDeals(coordinate, locationList) {
+        const resultRecent = {};
+        const resultProvious = {};
+        let resultRecentList = [];
+        let resultProviousList = [];
         try {
-            let resultRecent = [];
-            let resultProvious = [];
-
             const promises = locationList.map(async (info) => {
                 const sgg_cd = info.sgg_cd;
                 const dealsRecent = await this.repository.findRecentlyDeals(coordinate, sgg_cd)
-                resultRecent = resultRecent.concat(dealsRecent);
+                resultRecent[sgg_cd] = dealsRecent;
 
                 const dealsProvious = await this.repository.findProviousOfRecentlyDeals(dealsRecent, sgg_cd)
-                resultProvious = resultProvious.concat(dealsProvious);
+                resultProvious[sgg_cd] = dealsProvious;
             })
             await Promise.all(promises);
-            return { resultRecent, resultProvious };
+
+            for (const info of locationList) {
+                resultRecentList = resultRecentList.concat(resultRecent[info.sgg_cd]);
+                resultProviousList = resultProviousList.concat(resultProvious[info.sgg_cd]);
+            }
+
+            return { resultRecent: resultRecentList, resultProvious: resultProviousList };
         } catch (error) {
             RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.DB_FIND_ERROR);
         }

--- a/back/src/application/service/locationForm.js
+++ b/back/src/application/service/locationForm.js
@@ -14,8 +14,11 @@ module.exports = class {
 
             const promises = locationList.map(async (info) => {
                 const ssg_cd = info.sgg_cd;
-                const deals = await this.repository.findRecentlyDeals(coordinate, ssg_cd)
-                result = result.concat(deals);
+                const year = new Date().getFullYear();
+                const month = new Date().getMonth() + 1;
+                const dealsRecentIdList = await this.repository.findRecentlyDealsId(year, month, ssg_cd);
+                const dealsRecent = await this.repository.findDealsOfIdCoordinate(dealsRecentIdList, coordinate, ssg_cd);
+                result = result.concat(dealsRecent);
             })
             await Promise.all(promises);
             return result;
@@ -24,7 +27,7 @@ module.exports = class {
         }
     }
 
-    async findProviousOfRecentlyDeals(coordinate, locationList) {
+    async findProviousOfRecentlyDeals(coordinate, year, month, locationList) {
         const resultRecent = {};
         const resultProvious = {};
         let resultRecentList = [];
@@ -32,7 +35,8 @@ module.exports = class {
         try {
             const promises = locationList.map(async (info) => {
                 const sgg_cd = info.sgg_cd;
-                const dealsRecent = await this.repository.findRecentlyDeals(coordinate, sgg_cd)
+                const dealsRecentIdList = await this.repository.findRecentlyDealsId(year, month, sgg_cd);
+                const dealsRecent = await this.repository.findDealsOfIdCoordinate(dealsRecentIdList, coordinate, sgg_cd);
                 resultRecent[sgg_cd] = dealsRecent;
 
                 const dealsProvious = await this.repository.findProviousOfRecentlyDeals(dealsRecent, sgg_cd)

--- a/back/src/application/service/locationForm.js
+++ b/back/src/application/service/locationForm.js
@@ -34,7 +34,7 @@ module.exports = class {
                 const dealsRecent = await this.repository.findRecentlyDeals(coordinate, sgg_cd)
                 resultRecent = resultRecent.concat(dealsRecent);
 
-                const dealsProvious = await this.repository.findProviousOfRecentlyDeals(coordinate, sgg_cd)
+                const dealsProvious = await this.repository.findProviousOfRecentlyDeals(dealsRecent, sgg_cd)
                 resultProvious = resultProvious.concat(dealsProvious);
             })
             await Promise.all(promises);

--- a/back/src/config/responseState.js
+++ b/back/src/config/responseState.js
@@ -25,7 +25,8 @@ module.exports = {
             logger.error({
                 code: Type.code,
                 message: Type.message,
-                detail: `${error}`
+                detail: `${error}`,
+                stack: `${error.stack}`
             })
             throw Type;
         }

--- a/back/src/config/winston.js
+++ b/back/src/config/winston.js
@@ -7,7 +7,7 @@ const { combine, timestamp, printf } = Winston.format;
 
 // Define log format
 const logFormat = printf(info => {
-    return `[${info.timestamp}] ${info.level}: ${info.message}` + (info.code ? `[code: ${info.code}]` : '') + (info.detail ? `detail: ${info.detail}` : '')
+    return `[${info.timestamp}] ${info.level}: ${info.message}` + (info.code ? `[code: ${info.code}]` : '') + (info.detail ? `detail: ${info.detail}` : '') + (info.stack ? `\n stack:\n ${info.stack}` : '')
 });
 
 /*

--- a/back/src/controllers/displayDealsController.js
+++ b/back/src/controllers/displayDealsController.js
@@ -30,10 +30,12 @@ exports.ProviousOfRecentlyDeals = async (options) => {
         max_x: options.body.bounds.max.x,
         max_y: options.body.bounds.max.y
     }
+    const year = options.body.year || new Date().getFullYear();
+    const month = options.body.month || new Date().getMonth() + 1;
 
     try {
         const locationList = await locationService.findIncluedArea(coordinate);
-        return await locationFormService.findProviousOfRecentlyDeals(coordinate, locationList);
+        return await locationFormService.findProviousOfRecentlyDeals(coordinate, year, month, locationList);
     } catch (error) {
         RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.CONTROLLER_ERROR_NAME('ProviousOfRecentlyDeals'))
     }

--- a/back/src/domain/deal.js
+++ b/back/src/domain/deal.js
@@ -1,5 +1,5 @@
 module.exports = class {
-    constructor(dong, name, jibun, deal_amount, build_year, deal_year, deal_month, deal_day, area, floor, house_type, cancel_deal_type, cancel_deal_day, req_gbn, x, y) {
+    constructor(dong, name, jibun, deal_amount, build_year, deal_year, deal_month, deal_day, area, floor, house_type, cancel_deal_type, cancel_deal_day, req_gbn, x, y, provious = null) {
         this.dong = dong // string
         this.name = name // string
         this.jibun = jibun // string
@@ -16,5 +16,6 @@ module.exports = class {
         this.req_gbn = req_gbn // string
         this.x = x // float
         this.y = y // float
+        this.provious = provious // int
     }
 }

--- a/back/src/infrastructure/database/orm/sequelize/models/location.js
+++ b/back/src/infrastructure/database/orm/sequelize/models/location.js
@@ -24,22 +24,22 @@ module.exports = class Location extends Sequelize.Model {
                 allowNull: false
             },
             min_x: {
-                type: Sequelize.FLOAT,
+                type: Sequelize.DOUBLE(),
                 allowNull: true
 
             },
             min_y: {
-                type: Sequelize.FLOAT,
+                type: Sequelize.DOUBLE(),
                 allowNull: true
 
             },
             max_x: {
-                type: Sequelize.FLOAT,
+                type: Sequelize.DOUBLE(),
                 allowNull: true
 
             },
             max_y: {
-                type: Sequelize.FLOAT,
+                type: Sequelize.DOUBLE(),
                 allowNull: true
 
             }

--- a/back/src/infrastructure/database/orm/sequelize/models/locationForm.js
+++ b/back/src/infrastructure/database/orm/sequelize/models/locationForm.js
@@ -71,9 +71,11 @@ module.exports = (sgg_cd) => {
                 y: {
                     type: Sequelize.FLOAT,
                     allowNull: false
-
+                },
+                provious: {
+                    type: Sequelize.INTEGER,
+                    allowNull: true
                 }
-
             }, {
                 sequelize,
                 timestamps: false,

--- a/back/src/infrastructure/database/orm/sequelize/models/locationForm.js
+++ b/back/src/infrastructure/database/orm/sequelize/models/locationForm.js
@@ -64,12 +64,12 @@ module.exports = (sgg_cd) => {
                     allowNull: true
                 },
                 x: {
-                    type: Sequelize.FLOAT,
+                    type: Sequelize.DOUBLE(),
                     allowNull: false
 
                 },
                 y: {
-                    type: Sequelize.FLOAT,
+                    type: Sequelize.DOUBLE(),
                     allowNull: false
                 },
                 provious: {

--- a/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
+++ b/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
@@ -95,6 +95,7 @@ module.exports = class extends LocationFormrepository {
                     // x: { [Op.and]: [{ [Op.gt]: coordinate.min_x }, { [Op.lt]: coordinate.max_x }] },
                     // y: { [Op.and]: [{ [Op.gt]: coordinate.min_y }, { [Op.lt]: coordinate.max_y }] }
                 },
+                order: [['provious', 'ASC']],
                 raw: true
             })
 
@@ -107,17 +108,17 @@ module.exports = class extends LocationFormrepository {
                 search.push(deal);
             }
         }
-        console.log(`${ssg_cd}: `, search.length);
         return search;
     }
 
-    async findProviousOfRecentlyDeals(dealsList, ssg_cd) {
+    async findProviousOfRecentlyDeals(deals, ssg_cd) {
         // 좌표기준 건물의 거래 내역중 가장 최근 거래 내역 한개만을 표시(house_type 무시)
         const idList = [];
-        for (deal of dealsList) {
+        const table = this.models[ssg_cd];
+
+        for (const deal of deals) {
             idList.push(deal.provious);
         }
-        const table = this.models[ssg_cd];
         const results = await table.findAll({
             where: {
                 id: { [Op.in]: idList }

--- a/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
+++ b/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
@@ -1,6 +1,6 @@
 const db = require('../orm/sequelize/models');
 const { Op } = require('sequelize');
-const Sequelize = require('sequelize');
+// const Sequelize = require('sequelize');
 const env = process.env.NODE_ENV || 'development';
 const config = require('../../../config/config.json')[env];
 const LocationFormrepository = require('../../../application/interface/LocationFormRepository')
@@ -10,12 +10,10 @@ module.exports = class extends LocationFormrepository {
         super();
         this.models = database.LocationForm;
         this.sequelize = database.sequelize;
-        if (!global.globalLocationFormRepositoryMemory) {
-            global.globalLocationFormRepositoryMemory = {
-                findRecentlyDeals: {},
-                findProviousOfRecentlyDeals: {}
-            };
+        if (!global.repositorybuffer) {
+            global.repositorybuffer = {};
         }
+        this.buffer = global.repositorybuffer
     }
 
     async initMemory() {
@@ -67,8 +65,7 @@ module.exports = class extends LocationFormrepository {
                     { deal_year: { [Op.lt]: deal.deal_year } }, {
                         [Op.and]: [
                             { deal_year: deal.deal_year },
-                            { deal_month: { [Op.lte]: deal.deal_month } },
-                            { deal_day: { [Op.lt]: deal.deal_day } }
+                            { deal_month: { [Op.lt]: deal.deal_month } }
                         ]
                     }
                 ],
@@ -85,30 +82,47 @@ module.exports = class extends LocationFormrepository {
         })
     }
 
-    async findRecentlyDeals(coordinate, ssg_cd) {
+    async findRecentlyDealsId(year, month, ssg_cd) {
         // 좌표기준 건물의 거래 내역중 가장 최근 거래 내역 한개만을 표시(house_type 무시)
-        if (!globalLocationFormRepositoryMemory.findRecentlyDeals[ssg_cd]) {
-            const table = this.models[ssg_cd];
-            const results = await table.findAll({
-                where: {
-                    id: { [Op.in]: [Sequelize.literal('select max(id) as id from' + (config.dialect === 'sqlite' ? ` '${ssg_cd}' ` : ` ${config.database}.${ssg_cd} `) + 'group by dong,name')] }
-                    // x: { [Op.and]: [{ [Op.gt]: coordinate.min_x }, { [Op.lt]: coordinate.max_x }] },
-                    // y: { [Op.and]: [{ [Op.gt]: coordinate.min_y }, { [Op.lt]: coordinate.max_y }] }
-                },
-                order: [['provious', 'ASC']],
-                raw: true
-            })
-
-            globalLocationFormRepositoryMemory.findRecentlyDeals[ssg_cd] = results;
+        if (!this.buffer[ssg_cd]) {
+            this.buffer[ssg_cd] = {};
         }
-
-        const search = [];
-        for (const deal of globalLocationFormRepositoryMemory.findRecentlyDeals[ssg_cd]) {
-            if (deal.x > coordinate.min_x && deal.x < coordinate.max_x && deal.y > coordinate.min_y && deal.y < coordinate.max_y) {
-                search.push(deal);
+        if (this.buffer[ssg_cd][`${year}${month}`]) {
+            const idList = this.buffer[ssg_cd][`${year}${month}`];
+            const maxIdDeal = await this.findMaxOne('id', ssg_cd);
+            if (idList[idList.length - 1] === maxIdDeal.id) {
+                return idList;
             }
         }
-        return search;
+
+        const results = await this.sequelize.query(
+            `select max(id) as id 
+            from (SELECT * FROM` + (config.dialect === 'sqlite' ? ` '${ssg_cd}' ` : ` ${config.database}.${ssg_cd} `) +
+            `WHERE deal_year < ${year} OR (deal_year = ${year} AND deal_month <= ${month})) AS a
+            group by dong,name
+            order by id`,
+            { type: this.sequelize.QueryTypes.SELECT })
+        const idList = []
+        for (const id of results) {
+            idList.push(id.id);
+        }
+        this.buffer[ssg_cd][`${year}${month}`] = idList;
+        return idList
+    }
+
+    async findDealsOfIdCoordinate(idList, coordinate, ssg_cd) {
+        // 좌표기준 건물의 거래 내역중 가장 최근 거래 내역 한개만을 표시(house_type 무시)
+        const table = this.models[ssg_cd];
+        const results = await table.findAll({
+            where: {
+                id: { [Op.in]: idList },
+                x: { [Op.and]: [{ [Op.gt]: coordinate.min_x }, { [Op.lt]: coordinate.max_x }] },
+                y: { [Op.and]: [{ [Op.gt]: coordinate.min_y }, { [Op.lt]: coordinate.max_y }] }
+            },
+            order: [['provious', 'ASC']],
+            raw: true
+        })
+        return results;
     }
 
     async findProviousOfRecentlyDeals(deals, ssg_cd) {

--- a/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
+++ b/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
@@ -44,6 +44,40 @@ module.exports = class extends LocationFormrepository {
         return await this.models[sgg_cd].findOne(ormOptions);
     }
 
+    async findDealsYM(year, month, name, sgg_cd) {
+        return await this.models[sgg_cd].findAll({
+            where: {
+                deal_year: year,
+                deal_month: month,
+                house_type: name
+            },
+            raw: true
+        })
+    }
+
+    async findProviousDealOne(deal, sgg_cd) {
+        const limit = 3
+        return await this.models[sgg_cd].findOne({
+            where: {
+                name: deal.name,
+                area: { [Op.and]: [{ [Op.gte]: Math.floor(deal.area) }, { [Op.lt]: Math.floor(deal.area) + 1 }] },
+                dong: deal.dong,
+                house_type: deal.house_type,
+                [Op.or]: [
+                    { deal_year: { [Op.lt]: deal.deal_year } }, {
+                        [Op.and]: [
+                            { deal_year: deal.deal_year },
+                            { deal_month: { [Op.lte]: deal.deal_month } },
+                            { deal_day: { [Op.lt]: deal.deal_day } }
+                        ]
+                    }
+                ],
+                floor: (deal.floor >= 0 ? { [Op.and]: [{ [Op.gte]: (deal.floor - limit > 0 ? deal.floor - limit : 1) }, { [Op.lte]: deal.floor + limit }] } : { [Op.lt]: 0 })
+            },
+            order: [['deal_year', 'DESC'], ['deal_month', 'DESC'], ['deal_day', 'DESC']]
+        });
+    }
+
     async findRecentlyDealOnType(hous_type, sgg_cd) {
         return await this.models[sgg_cd].findOne({
             where: { house_type: hous_type },

--- a/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
+++ b/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
@@ -111,42 +111,20 @@ module.exports = class extends LocationFormrepository {
         return search;
     }
 
-    async findProviousOfRecentlyDeals(coordinate, ssg_cd) {
+    async findProviousOfRecentlyDeals(dealsList, ssg_cd) {
         // 좌표기준 건물의 거래 내역중 가장 최근 거래 내역 한개만을 표시(house_type 무시)
-
-        if (!globalLocationFormRepositoryMemory.findProviousOfRecentlyDeals[ssg_cd]) {
-            const results = await this.sequelize.query(
-                `select AA.*,BB.max_id
-                from projectdev.${ssg_cd} as AA
-                inner join
-                    (select max(id) as s_max_id, max_id
-                    from
-                        (select a.*,b.id as max_id
-                        from projectdev.${ssg_cd} as a
-                        inner join
-                            (select *
-                            from projectdev.${ssg_cd}
-                            where id in 
-                                (SELECT max(id)
-                                FROM projectdev.${ssg_cd}
-                                group by dong,name)) as b
-                        on a.dong = b.dong and a.name = b.name
-                        where a.id != b.id and a.area = b.area and ((b.floor > 0 and a.floor > 0) and (a.floor >= b.floor-3 and a.floor <= b.floor+3) or (b.floor < 0 and a.floor < 0)))as s
-                    group by max_id) as BB
-                on AA.id = BB.s_max_id
-                order by max_id`, { type: this.sequelize.QueryTypes.SELECT })
-
-            globalLocationFormRepositoryMemory.findProviousOfRecentlyDeals[ssg_cd] = results;
+        const idList = [];
+        for (deal of dealsList) {
+            idList.push(deal.provious);
         }
-
-        const search = [];
-        for (const deal of globalLocationFormRepositoryMemory.findProviousOfRecentlyDeals[ssg_cd]) {
-            if (deal.x > coordinate.min_x && deal.x < coordinate.max_x && deal.y > coordinate.min_y && deal.y < coordinate.max_y) {
-                search.push(deal);
-            }
-        }
-        console.log(`${ssg_cd}: `, search.length);
-        return search;
+        const table = this.models[ssg_cd];
+        const results = await table.findAll({
+            where: {
+                id: { [Op.in]: idList }
+            },
+            raw: true
+        })
+        return results;
     }
 
     async findMaxOne(attribute, sgg_cd) {

--- a/back/tests/unit/locationForm.spec.js
+++ b/back/tests/unit/locationForm.spec.js
@@ -5,7 +5,11 @@ const DealDomain = require('../../src/domain/deal');
 
 describe('findIncludeArea module test', () => {
     const fakeRepository = {
-        findRecentlyDeals: (coordinate, ssg_cd) => {
+        findRecentlyDealsId: (coordinate, ssg_cd) => {
+            const deals = [{ id: 1 }];
+            return deals;
+        },
+        findDealsOfIdCoordinate: (IdList, coordinate, ssg_cd) => {
             const deals = [new DealDomain('내수동', '경희궁의아침3단지', '72', 200000, 2004, 2022, 1, 14, 150.48, 3, '아파트', 0, '', '중개거래', 126.972, 37.5736)];
             return deals;
         }


### PR DESCRIPTION
### 1. 직전 거래 정보 탐색 속도 개선을 위한 테이블 수정
- provious 속성을 추가하여 직전 거래 정보를 가지는 id 값을 저장
- 해당 id 정보를 기준으로 빠른 직전 거래정보의 탐색이 가능

### 2. 기존 최근 거래정보 탐색 로직 개선
- 기존의 서브쿼리를 분리하여 두개의 메인쿼리 문을 생성하여 메소드로 추가
- 이전 한 테이블 기준 검색 쿼리 약 300ms  -> 개선 쿼리 약 150ms 정도로 응답속도가 개선됨

### 3. 기존 테이블의 좌표 정보 속성의 타입 변경
 - 기존 float(소수점4자리)에서 double(소수점8자리)로 변경하여 좌표의 정밀성 개선

### 4. 같은 정보를 빈번하게 요청하는 쿼리 정보의 buffer 처리
- 비교적 무거운 쿼리의 테이블 조회를 줄이기 위한 buffer에 임시 저장하여 응답
- 응답속도 약 10%정도의 개선이 이루어졌으며 DB 조회 최소화