### PR TITLE
월별 추이정보 제공 기능

### DIFF
--- a/back/src/application/interface/LocationFormRepository.js
+++ b/back/src/application/interface/LocationFormRepository.js
@@ -61,4 +61,9 @@ module.exports = class {
         // coordinate = {min_x,min_y,max_x,max_y}
         throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
     }
+
+    async monthlyTradingAmountAVG(coordinate, sgg_cd) {
+        // coordinate = {min_x,min_y,max_x,max_y}
+        throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
+    }
 }

--- a/back/src/application/interface/LocationFormRepository.js
+++ b/back/src/application/interface/LocationFormRepository.js
@@ -56,4 +56,9 @@ module.exports = class {
         // deals = [deal,deal, ...]
         throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
     }
+
+    async monthlyTradingVolum(coordinate, sgg_cd) {
+        // coordinate = {min_x,min_y,max_x,max_y}
+        throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
+    }
 }

--- a/back/src/application/service/locationForm.js
+++ b/back/src/application/service/locationForm.js
@@ -69,4 +69,24 @@ module.exports = class {
             return RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.DB_FIND_ERROR_NAME(sgg_cd));
         }
     }
+
+    async findMonthlyTradingVolum(coordinate, locationList) {
+        validator.coordinate(coordinate);
+        const result = {};
+
+        try {
+            const promises = locationList.map(async (info) => {
+                const sgg_cd = info.sgg_cd;
+                const tradingVolum = await this.repository.monthlyTradingVolum(coordinate, sgg_cd);
+                // console.log(sgg_cd, tradingVolum.length)
+                result[sgg_cd] = tradingVolum;
+            })
+
+            await Promise.all(promises);
+            // console.log(Object.keys(result));
+            return result;
+        } catch (error) {
+            return RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.DB_FIND_ERROR);
+        }
+    }
 }

--- a/back/src/application/service/locationForm.js
+++ b/back/src/application/service/locationForm.js
@@ -89,4 +89,22 @@ module.exports = class {
             return RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.DB_FIND_ERROR);
         }
     }
+
+    async findMonthlyTradingAmountAVG(coordinate, locationList) {
+        validator.coordinate(coordinate);
+        const result = {};
+
+        try {
+            const promises = locationList.map(async (info) => {
+                const sgg_cd = info.sgg_cd;
+                const amountAVG = await this.repository.monthlyTradingAmountAVG(coordinate, sgg_cd);
+                result[sgg_cd] = amountAVG;
+            })
+
+            await Promise.all(promises);
+            return result;
+        } catch (error) {
+            return RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.DB_FIND_ERROR);
+        }
+    }
 }

--- a/back/src/controllers/displayGraphController.js
+++ b/back/src/controllers/displayGraphController.js
@@ -1,0 +1,22 @@
+const LocationService = require('../application/service/location');
+const LocationFormService = require('../application/service/locationForm');
+
+const RESPONSE = require('../config/responseState');
+
+exports.monthlyTradingVolum = async (options) => {
+    const locationService = new LocationService(options.locationRepository);
+    const locationFormService = new LocationFormService(options.locationFormRepository);
+    const coordinate = {
+        min_x: options.body.bounds.min.x,
+        min_y: options.body.bounds.min.y,
+        max_x: options.body.bounds.max.x,
+        max_y: options.body.bounds.max.y
+    }
+
+    try {
+        const locationList = await locationService.findIncluedArea(coordinate);
+        return await locationFormService.findMonthlyTradingVolum(coordinate, locationList);
+    } catch (error) {
+        RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.CONTROLLER_ERROR_NAME('monthlyTradingVolum'))
+    }
+}

--- a/back/src/controllers/displayGraphController.js
+++ b/back/src/controllers/displayGraphController.js
@@ -20,3 +20,21 @@ exports.monthlyTradingVolum = async (options) => {
         RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.CONTROLLER_ERROR_NAME('monthlyTradingVolum'))
     }
 }
+
+exports.monthlyTradingAmountAVG = async (options) => {
+    const locationService = new LocationService(options.locationRepository);
+    const locationFormService = new LocationFormService(options.locationFormRepository);
+    const coordinate = {
+        min_x: options.body.bounds.min.x,
+        min_y: options.body.bounds.min.y,
+        max_x: options.body.bounds.max.x,
+        max_y: options.body.bounds.max.y
+    }
+
+    try {
+        const locationList = await locationService.findIncluedArea(coordinate);
+        return await locationFormService.findMonthlyTradingAmountAVG(coordinate, locationList);
+    } catch (error) {
+        RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.CONTROLLER_ERROR_NAME('monthlyTradingAmountAVG'))
+    }
+}

--- a/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
+++ b/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
@@ -174,4 +174,23 @@ module.exports = class extends LocationFormrepository {
             order: ['dong']
         })
     }
+
+    async monthlyTradingAmountAVG(coordinate, sgg_cd) {
+        return await this.models[sgg_cd].findAll({
+            attributes: ['dong', 'deal_year', 'deal_month',
+                [this.sequelize.literal('SUM(case when house_type=\'아파트\' then deal_amount end)'), '아파트amount'],
+                [this.sequelize.literal('sum(case when house_type=\'아파트\' then area end)'), '아파트area'],
+                [this.sequelize.literal('SUM(case when house_type=\'연립다세대\' then deal_amount end)'), '연립다세대amount'],
+                [this.sequelize.literal('sum(case when house_type=\'연립다세대\' then area end)'), '연립다세대area'],
+                [this.sequelize.literal('SUM(case when house_type=\'오피스텔\' then deal_amount end)'), '오피스텔amount'],
+                [this.sequelize.literal('sum(case when house_type=\'오피스텔\' then area end)'), '오피스텔area']
+            ],
+            where: {
+                x: { [Op.and]: [{ [Op.gt]: coordinate.min_x }, { [Op.lt]: coordinate.max_x }] },
+                y: { [Op.and]: [{ [Op.gt]: coordinate.min_y }, { [Op.lt]: coordinate.max_y }] }
+            },
+            group: ['dong', 'deal_year', 'deal_month'],
+            order: ['dong']
+        })
+    }
 }

--- a/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
+++ b/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
@@ -158,4 +158,16 @@ module.exports = class extends LocationFormrepository {
     async bulkCreate(deals, sgg_cd) {
         return await this.models[sgg_cd].bulkCreate(deals);
     }
+
+    async monthlyTradingVolum(coordinate, sgg_cd) {
+        return await this.models[sgg_cd].findAll({
+            attributes: ['dong', 'deal_year', 'deal_month', [this.sequelize.fn('COUNT', this.sequelize.col('name')), 'count']],
+            where: {
+                x: { [Op.and]: [{ [Op.gt]: coordinate.min_x }, { [Op.lt]: coordinate.max_x }] },
+                y: { [Op.and]: [{ [Op.gt]: coordinate.min_y }, { [Op.lt]: coordinate.max_y }] }
+            },
+            group: ['dong', 'deal_year', 'deal_month'],
+            order: ['dong']
+        })
+    }
 }

--- a/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
+++ b/back/src/infrastructure/database/repositories/LocationFormRepositoryMysql.js
@@ -161,7 +161,11 @@ module.exports = class extends LocationFormrepository {
 
     async monthlyTradingVolum(coordinate, sgg_cd) {
         return await this.models[sgg_cd].findAll({
-            attributes: ['dong', 'deal_year', 'deal_month', [this.sequelize.fn('COUNT', this.sequelize.col('name')), 'count']],
+            attributes: ['dong', 'deal_year', 'deal_month', [this.sequelize.fn('COUNT', this.sequelize.col('house_type')), 'count'],
+                [this.sequelize.literal('COUNT(case when house_type=\'아파트\' then 1 end)'), '아파트'],
+                [this.sequelize.literal('COUNT(case when house_type=\'연립다세대\' then 1 end)'), '연립다세대'],
+                [this.sequelize.literal('COUNT(case when house_type=\'오피스텔\' then 1 end)'), '오피스텔']
+            ],
             where: {
                 x: { [Op.and]: [{ [Op.gt]: coordinate.min_x }, { [Op.lt]: coordinate.max_x }] },
                 y: { [Op.and]: [{ [Op.gt]: coordinate.min_y }, { [Op.lt]: coordinate.max_y }] }

--- a/back/src/infrastructure/express/routes/index.js
+++ b/back/src/infrastructure/express/routes/index.js
@@ -22,4 +22,10 @@ router.post('/traingVolum', async (req, res, next) => {
         .catch((error) => next(error));
 })
 
+router.post('/amountAVG', async (req, res, next) => {
+    await displayGraphController.monthlyTradingAmountAVG(Object.assign(app.locals.options, { body: req.body.mapState }))
+        .then((result) => res.json({ status: 200, data: result }))
+        .catch((error) => next(error));
+})
+
 module.exports = router;

--- a/back/src/infrastructure/express/routes/index.js
+++ b/back/src/infrastructure/express/routes/index.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const displayDealsController = require('../../../controllers/displayDealsController');
+const displayGraphController = require('../../../controllers/displayGraphController');
 
 const router = express.Router()
 
@@ -11,6 +12,12 @@ router.post('/deal', async (req, res, next) => {
 
 router.post('/proviousDeal', async (req, res, next) => {
     await displayDealsController.ProviousOfRecentlyDeals(Object.assign(app.locals.options, { body: req.body.mapState }))
+        .then((result) => res.json({ status: 200, data: result }))
+        .catch((error) => next(error));
+})
+
+router.post('/traingVolum', async (req, res, next) => {
+    await displayGraphController.monthlyTradingVolum(Object.assign(app.locals.options, { body: req.body.mapState }))
         .then((result) => res.json({ status: 200, data: result }))
         .catch((error) => next(error));
 })

--- a/front/components/chart.vue
+++ b/front/components/chart.vue
@@ -52,6 +52,9 @@ export default {
     },
     options() {
       return this.$store.state.dealList.options;
+    },
+    refreshMarker() {
+      return this.$store.state.dealList.refreshMarker;
     }
   },
   watch: {
@@ -61,7 +64,11 @@ export default {
     },
     tradingVolumList(newVal, oldVal) {
       this.setGraphData(newVal);
+    },
+    refreshMarker(newVal, oldVal) {
+      this.setGraphData(this.tradingVolumList);
     }
+
   },
   methods: {
     setDate(data) {
@@ -74,6 +81,7 @@ export default {
       const labels = [];
       this.data.datasets.splice(0)
       const dateInfo = this.options.date;
+      const houseType = this.options.type;
       const date = {
         deal_year: dateInfo.min[0],
         deal_month: dateInfo.min[1]
@@ -102,7 +110,7 @@ export default {
 
             for (const date of labels) {
               if (volumList[i] && dong == volumList[i].dong && date == this.setDate(volumList[i])) {
-                countList.push(volumList[i].count);
+                countList.push((houseType['오피스텔'] ? volumList[i]['오피스텔'] : 0) + (houseType['아파트'] ? volumList[i]['아파트'] : 0) + (houseType['연립다세대'] ? volumList[i]['연립다세대'] : 0));
                 i++;
               } else {
                 countList.push(0);

--- a/front/components/chart.vue
+++ b/front/components/chart.vue
@@ -1,42 +1,140 @@
 <template>
   <div>
     <canvas id="myChart"></canvas>
+    <div v-if="loading === true" class="loading">loading...</div>
   </div>
 </template>
 
 <script>
 import Chart from 'chart.js';
-export default{
-  data(){
-    return{
-      labels:['January','February','March','April','May','June'],
-      data:{
+export default {
+  data() {
+    return {
+      loading: false,
+      labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+      data: {
         labels: this.labels,
         datasets: [{
-          label: 'dataset',
+          label: '',
           backgroundColor: '#2E495E00',
           borderColor: 'rgb(255, 99, 132)',
-          data: [0, 10, 20, 30, 40, 50, 55],
+          data: [0, 0, 0, 0, 0, 0, 0],
         }]
       },
-      config:{
+      config: {
         type: 'line',
         data: this.data,
         options: {}
       },
-      chart:null,
+      chart: null,
     }
   },
-  mounted(){
-    this.data.labels=this.labels;
-    this.config.data=this.data;
+  mounted() {
+    //this.data.labels=this.labels;
+    this.config.data = this.data;
+    console.log(this.data.labels);
 
     const myChart = new Chart(
       document.getElementById('myChart'),
       this.config
     );
-    this.chart=myChart;
+    this.chart = myChart;
+    this.setGraphData(this.tradingVolumList);
+  },
+  computed: {
+    tradingVolumList() {
+      return this.$store.state.graph.tradingVolumList;
+    },
+    mapState() {
+      return this.$store.state.dealList.mapState;
+    },
+    dealList() {
+      return this.$store.state.dealList.dealList;
+    },
+    options() {
+      return this.$store.state.dealList.options;
+    }
+  },
+  watch: {
+    dealList(newVal, oldVal) {
+      this.loading = true;
+      this.setTradingVolumList();
+    },
+    tradingVolumList(newVal, oldVal) {
+      this.setGraphData(newVal);
+    }
+  },
+  methods: {
+    setTradingVolumList() {
+      this.$store.dispatch('graph/setTradingVolum', this.mapState);
+    },
+    async setGraphData(tradingVolumList) {
+      const labels = [];
+      this.data.datasets.splice(0)
+      const dateInfo = this.options.date;
+
+      for (const locationCode in tradingVolumList) {
+        const volumList = tradingVolumList[locationCode];
+        if (volumList.length === 0) {
+          continue;
+        }
+
+        let dong = volumList[0].dong;
+        let countList = [];
+
+        for (const data of volumList) {
+          if (dong != data.dong) {
+            this.data.datasets.push({
+              label: dong,
+              backgroundColor: '#2E495E00',
+              borderColor: `rgb(${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)})`,
+              data: countList
+            });
+            dong = data.dong;
+            countList = [];
+          }
+
+          if ((dateInfo.min[0] < data.deal_year || (dateInfo.min[0] == data.deal_year && dateInfo.min[1] <= data.deal_month)) &&
+            (dateInfo.max[0] > data.deal_year || (dateInfo.max[0] == data.deal_year && dateInfo.max[1] >= data.deal_month))) {
+            if (!labels.includes(`${data.deal_year}.${data.deal_month}`)) {
+              labels.push(`${data.deal_year}.${data.deal_month}`);
+            }
+            countList.push(data.count);
+          }
+
+          if (data == volumList[volumList.length - 1]) {
+            this.data.datasets.push({
+              label: dong,
+              backgroundColor: '#2E495E00',
+              borderColor: `rgb(${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)})`,
+              data: countList
+            });
+          }
+        }
+
+      }
+
+      this.data.labels = labels;
+      this.chart.update();
+
+      this.loading = false;
+    },
+    setColor() {
+      return `rgb(${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)})`
+    }
   }
 }
 
-</script>ㄴ
+</script>
+
+<style>
+.loading {
+  position: absolute;
+  left: 0px;
+  top: 0px;
+  width: 100%;
+  height: 100vh;
+  background-color: #ffffff9a;
+  text-align: center;
+}
+</style>

--- a/front/components/graph.vue
+++ b/front/components/graph.vue
@@ -1,66 +1,65 @@
 <template>
   <div class="invisible">
     <v-navigation-drawer v-model="drawer" :mini-variant.sync="search" permanent :width="600" id="box">
-      
+
       <v-list-item class="searchTitle" style="padding:0px 10px 0px 10px;">
-        <v-btn icon hide-details @click.stop="search = !search" >
-            <v-icon hide-details>mdi-chart-line</v-icon>
+        <v-btn icon hide-details @click.stop="search = !search">
+          <v-icon hide-details>mdi-chart-line</v-icon>
         </v-btn>
         <v-list-item-title style="text-align: center;">
-          월별 거래량 및 평당 평균 거래가 변동률
+          월별 거래량 및 평당 거래가
         </v-list-item-title>
       </v-list-item>
 
       <v-divider></v-divider>
 
       <div v-if="!search" class="chart">
-          <Chart></Chart>
+        <Chart></Chart>
       </div>
-      
+
     </v-navigation-drawer>
-</div>
+  </div>
 
 
 </template>
 
 <script>
-  import Chart from '~/components/chart.vue';
+import Chart from '~/components/chart.vue';
 
-  export default {
+export default {
 
-    data () {
-      return {
-        drawer: true,
-        search: true,
-        mini:true,
-      }
-    },
-    components:{
-      Chart
-    },
-    computed:{
-      dealList(){
-          return this.$store.state.dealList.dealList;
-      },
-      visibleDealsIndex(){
-          return this.$store.state.dealList.visibleDealsIndex;
-      },
-      refreshList(){
-          return this.$store.state.dealList.refreshList;
-      }
-    },
-    watch:{
-
-    },
-    methods:{
-      
+  data() {
+    return {
+      drawer: true,
+      search: true,
+      mini: true,
     }
+  },
+  components: {
+    Chart
+  },
+  computed: {
+    dealList() {
+      return this.$store.state.dealList.dealList;
+    },
+    visibleDealsIndex() {
+      return this.$store.state.dealList.visibleDealsIndex;
+    },
+    refreshList() {
+      return this.$store.state.dealList.refreshList;
+    }
+  },
+  watch: {
+
+  },
+  methods: {
+
   }
+}
 </script>
 
 <style>
-
-#box{
+#box {
   box-shadow: 0px 3px 1px -2px rgb(0 0 0 / 20%), 0px 2px 2px 0px rgb(0 0 0 / 14%), 0px 1px 5px 0px rgb(0 0 0 / 12%);
   border-radius: 8px;
 }
@@ -77,6 +76,7 @@
   letter-spacing: 1px;
   font-size: 6em;
 }
+
 .green {
   color: #00C48D;
 }
@@ -92,5 +92,4 @@
 .links {
   padding-top: 15px;
 }
-
 </style>

--- a/front/components/graph.vue
+++ b/front/components/graph.vue
@@ -9,6 +9,9 @@
         <v-list-item-title style="text-align: center;">
           월별 거래량 및 평당 거래가
         </v-list-item-title>
+        <v-btn icon hide-details @click.stop="setGraphType">
+          <v-icon hide-details>mdi-swap-horizontal</v-icon>
+        </v-btn>
       </v-list-item>
 
       <v-divider></v-divider>
@@ -53,7 +56,9 @@ export default {
 
   },
   methods: {
-
+    setGraphType() {
+      this.$store.dispatch('graph/setChangeType');
+    }
   }
 }
 </script>

--- a/front/components/groupSet.vue
+++ b/front/components/groupSet.vue
@@ -3,8 +3,8 @@
     <v-navigation-drawer v-model="drawer" :mini-variant.sync="search" permanent class="searchList" id="box">
 
       <v-list-item class="searchTitle" style="padding:0px 10px 0px 10px">
-        <v-btn icon hide-details @click.stop="search = !search" >
-            <v-icon hide-details>mdi-tune-variant</v-icon>
+        <v-btn icon hide-details @click.stop="search = !search">
+          <v-icon hide-details>mdi-tune-variant</v-icon>
         </v-btn>
         <v-list-item-title style="text-align: center;">검색 조건 설정</v-list-item-title>
       </v-list-item>
@@ -21,13 +21,7 @@
               <v-subheader class="subtitle">
                 <span v-text="firstTitleName"></span>
               </v-subheader>
-              <v-range-slider
-                      v-model="range"
-                      :max="max"
-                      :min="min"
-                      hide-details
-                      class="align-center"
-                    >
+              <v-range-slider v-model="range" :max="max" :min="min" hide-details class="align-center">
               </v-range-slider>
             </v-card>
           </v-list-item-content>
@@ -38,16 +32,18 @@
             <v-icon>mdi-home-city</v-icon>
           </v-list-item-icon>
           <v-list-item-content>
-              <v-row align="center" justify="space-around">
-                <v-card v-for="typeName in ['오피스텔','아파트','연립다세대']" :key="typeName">
-                  <v-btn class="typeBtn" v-if="options.type[typeName]" depressed color="primary" @click="changType(typeName)">
-                    <span style="font-size:3px;">{{typeName}}</span>
-                  </v-btn>
-                  <v-btn v-if="!options.type[typeName]" depressed @click="changType(typeName)">
-                    <span>{{typeName}}</span>
-                  </v-btn>
-                </v-card>
-              </v-row>
+            <v-row align="center" justify="space-around">
+              <v-card v-for="typeName in ['오피스텔', '아파트', '연립다세대']" :key="typeName">
+                <v-btn style="width:10px; height:30px" v-if="options.type[typeName]" depressed color="primary"
+                  @click="changType(typeName)">
+                  <span style="font-size:2px;">{{ typeName }}</span>
+                </v-btn>
+                <v-btn style="width:10px; height:30px" v-if="!options.type[typeName]" depressed
+                  @click="changType(typeName)">
+                  <span style="font-size:2px;">{{ typeName }}</span>
+                </v-btn>
+              </v-card>
+            </v-row>
           </v-list-item-content>
         </v-list-item>
 
@@ -60,22 +56,16 @@
               <v-subheader class="subtitle">
                 <span v-text="secondTitleName"></span>
               </v-subheader>
-              <v-range-slider
-                      v-model="amountRange"
-                      :max="amountMax"
-                      :min="amountMin"
-                      hide-details
-                      class="align-center"
-                    >
+              <v-range-slider v-model="amountRange" :max="amountMax" :min="amountMin" hide-details class="align-center">
               </v-range-slider>
             </v-card>
           </v-list-item-content>
         </v-list-item>
-      
-      
+
+
       </v-list>
 
-      
+
 
     </v-navigation-drawer>
   </div>
@@ -83,121 +73,125 @@
 </template>
 
 <script>
-  export default {
-    data () {
-      return {
-        drawer: true,
-        search: true,
-        mini:true,
+export default {
+  data() {
+    return {
+      drawer: true,
+      search: true,
+      mini: true,
 
-        firstTitleName:'',
-        min: -60,
-        max: 0,
-        range: [-12, 0],
-        date:{
-          min:[new Date().getFullYear(),new Date().getMonth()+1,-1,0],
-          max:[new Date().getFullYear(),new Date().getMonth()+1,0,0]
-        },
+      firstTitleName: '',
+      min: -60,
+      max: 0,
+      range: [-12, 0],
+      date: {
+        min: [new Date().getFullYear(), new Date().getMonth() + 1, -1, 0],
+        max: [new Date().getFullYear(), new Date().getMonth() + 1, 0, 0]
+      },
 
-        secondTitleName:'',
-        amountMin:1,
-        amountMax:1000,
-        amountRange:[1,1000],
-        amountScale:1000
-        
+      secondTitleName: '',
+      amountMin: 1,
+      amountMax: 1000,
+      amountRange: [1, 1000],
+      amountScale: 1000
+
+    }
+  },
+  mounted() {
+    this.setDate(this.range);
+    this.amountMax = this.options.AMOUNTMAX / this.amountScale;
+    this.amountRange[1] = this.options.AMOUNTMAX / this.amountScale;
+    this.setAmount(this.amountRange, this.amountScale);
+    console.log(this.amountRange);
+  },
+  computed: {
+    options() {
+      return this.$store.state.dealList.options;
+    }
+  },
+  watch: {
+    range(newVal, oldVal) {
+      this.setDate(newVal);
+    },
+    amountRange(newVal, oldVal) {
+      this.setAmount(newVal, this.amountScale);
+    }
+  },
+  methods: {
+    setAmount(amount, scale) {
+      amount = [amount[0] * scale, amount[1] * scale];
+      this.$store.dispatch('dealList/setAmount', amount)
+      if (amount[1] == this.options.AMOUNTMAX) {
+        this.secondTitleName = `${this.amountToString(amount[0])} ~ `
+      } else {
+        this.secondTitleName = `${this.amountToString(amount[0])} ~ ${this.amountToString(amount[1])}`
       }
     },
-    mounted(){
-      this.setDate(this.range);
-      this.amountMax=this.options.AMOUNTMAX/this.amountScale;
-      this.amountRange[1]=this.options.AMOUNTMAX/this.amountScale;
-      this.setAmount(this.amountRange,this.amountScale);
-      console.log(this.amountRange);
-    },
-    computed:{
-        options(){
-            return this.$store.state.dealList.options;
-        }
-    },
-    watch:{
-      range(newVal,oldVal){
-          this.setDate(newVal);
-      },
-      amountRange(newVal,oldVal){
-        this.setAmount(newVal,this.amountScale);
+    amountToString(amount) {
+      let result = '';
+      let a = parseInt(amount / 10000);
+      let b = amount % 10000;
+      if (a) {
+        result += `${a}억`
       }
+      if (b) {
+        result += `${b}만`
+      }
+      return result
     },
-    methods:{
-      setAmount(amount,scale){
-        amount=[amount[0]*scale,amount[1]*scale];
-        this.$store.dispatch('dealList/setAmount',amount)
-        if(amount[1]==this.options.AMOUNTMAX){
-          this.secondTitleName=`${this.amountToString(amount[0])} ~ `
-        }else{
-        this.secondTitleName=`${this.amountToString(amount[0])} ~ ${this.amountToString(amount[1])}`
-        }
-      },
-      amountToString(amount){
-            let result='';
-            let a =parseInt(amount/10000);
-            let b = amount%10000;
-            if(a){
-                result+=`${a}억`
-            }
-            if(b){
-              result+=`${b}만`
-            }
-            return result
-      },
-      changType(typeName){
-        this.$store.dispatch('dealList/changeType',typeName);
-      },
-      setDate(range){
-        let min = range[0];
-        
-        this.date.min[2]=(parseInt(min/12))
-        if(1>(min%12+this.date.min[1])){
-          this.date.min[2]--;
-          this.date.min[3]=12+(min%12);
-        }else{
-          this.date.min[3]=min%12;
-        }
+    changType(typeName) {
+      this.$store.dispatch('dealList/changeType', typeName);
+    },
+    setDate(range) {
+      let min = range[0];
 
-        let max = range[1];
-        
-        this.date.max[2]=(parseInt(max/12))
-        if(1>(max%12+this.date.max[1])){
-          this.date.max[2]--;
-          this.date.max[3]=12+(max%12);
-        }else{
-          this.date.max[3]=max%12;
-        }
-        this.$store.dispatch('dealList/setDate',{
-          min:[this.date.min[0]+this.date.min[2],this.date.min[1]+this.date.min[3]],
-          max:[this.date.max[0]+this.date.max[2],this.date.max[1]+this.date.max[3]]
-        });
-        this.firstTitleName=`${this.date.min[0]+this.date.min[2]}년 ${this.date.min[1]+this.date.min[3]}월~${this.date.max[0]+this.date.max[2]}년 ${this.date.max[1]+this.date.max[3]}월`
+      this.date.min[2] = (parseInt(min / 12))
+      if (1 > (min % 12 + this.date.min[1])) {
+        this.date.min[2]--;
+        this.date.min[3] = 12 + (min % 12);
+      } else {
+        this.date.min[3] = min % 12;
       }
+
+      let max = range[1];
+
+      this.date.max[2] = (parseInt(max / 12))
+      if (1 > (max % 12 + this.date.max[1])) {
+        this.date.max[2]--;
+        this.date.max[3] = 12 + (max % 12);
+      } else {
+        this.date.max[3] = max % 12;
+      }
+      this.$store.dispatch('dealList/setDate', {
+        min: [this.date.min[0] + this.date.min[2], this.date.min[1] + this.date.min[3]],
+        max: [this.date.max[0] + this.date.max[2], this.date.max[1] + this.date.max[3]]
+      });
+      this.firstTitleName = `${this.date.min[0] + this.date.min[2]}년 ${this.date.min[1] + this.date.min[3]}월~${this.date.max[0] + this.date.max[2]}년 ${this.date.max[1] + this.date.max[3]}월`
     }
   }
+}
 </script>
 
 <style>
-.searchTitle{
-    background-color: #ffffffaa;
+.searchTitle {
+  background-color: #ffffffaa;
 }
-.searchResult{
-    background-color: #ffffffaa;
+
+.searchResult {
+  background-color: #ffffffaa;
 }
-.subtitle{
+
+.subtitle {
   position: absolute;
   bottom: 10px;
   left: 10px;
 }
-.invisible{
+
+.invisible {
   background-color: #00000000;
 }
-#box{
+
+#box {
   box-shadow: 0px 3px 1px -2px rgb(0 0 0 / 20%), 0px 2px 2px 0px rgb(0 0 0 / 14%), 0px 1px 5px 0px rgb(0 0 0 / 12%);
   border-radius: 8px;
 }

--- a/front/components/naverMap.vue
+++ b/front/components/naverMap.vue
@@ -97,7 +97,7 @@ export default {
                         (options.date.max[0] < deal.deal_year || (options.date.max[0] == deal.deal_year && options.date.max[1] < deal.deal_month)) ||
                         (options.amount[0] > deal.deal_amount || (options.amount[1] != options.AMOUNTMAX && options.amount[1] < deal.deal_amount))
                     ) {
-                        if (dealProviousIndex < dealProviousLength && this.dealProviousList[dealProviousIndex].max_id == deal.id && this.dealProviousList[dealProviousIndex].name == deal.name) {
+                        if (deal.provious && dealProviousIndex < dealProviousLength && this.dealProviousList[dealProviousIndex].name == deal.name && this.dealProviousList[dealProviousIndex].id == deal.provious && this.dealProviousList[dealProviousIndex].dong == deal.dong) {
                             dealProviousIndex++;
                         }
                         deal.visible = false;
@@ -106,27 +106,26 @@ export default {
                 }
                 visibleList.push(index);
                 deal.visible = true;
-                let contextstyle = 'border: 2px solid rgb(0, 0, 0,0.5);'
-
-                if (dealProviousIndex < dealProviousLength && this.dealProviousList[dealProviousIndex].max_id == deal.id && this.dealProviousList[dealProviousIndex].name == deal.name) {
+                let contextstyle = 'border: 1px solid rgb(0, 0, 0,0.5);'
+                if (deal.provious && dealProviousIndex < dealProviousLength && this.dealProviousList[dealProviousIndex].name == deal.name && this.dealProviousList[dealProviousIndex].id == deal.provious && this.dealProviousList[dealProviousIndex].dong == deal.dong) {
                     let dealProvious = this.dealProviousList[dealProviousIndex]
 
                     if ((options.date.min[0] > dealProvious.deal_year || (options.date.min[0] == dealProvious.deal_year && options.date.min[1] > dealProvious.deal_month)) ||
                         (options.date.max[0] < dealProvious.deal_year || (options.date.max[0] == dealProvious.deal_year && options.date.max[1] < dealProvious.deal_month))) {
-                        contextstyle = 'border: 2px solid rgb(0, 0, 0,0.5);'
+                        contextstyle = 'border: 1px solid rgb(0, 0, 0,1);'
                     }
                     else if (deal.deal_amount < dealProvious.deal_amount) {
                         let blue = 2 * (deal.deal_amount / dealProvious.deal_amount > 0.5 ? 1 - deal.deal_amount / dealProvious.deal_amount : 0.5);
                         // blue = 105 + parseInt(150 * blue);
                         // const green = 255 - blue;
                         // console.log('blue:', blue, ', green:', green);
-                        contextstyle = `border: 2px solid rgb(${blue * 255}, 0, 0,0.75);`;
+                        contextstyle = `border: 2px solid rgb(0, 0, ${parseInt(blue * 255)},0.75);`;
                     } else if (deal.deal_amount > dealProvious.deal_amount) {
                         let red = 2 * (deal.deal_amount / dealProvious.deal_amount < 1.5 ? deal.deal_amount / dealProvious.deal_amount - 1 : 0.5);
                         // red = 105 + parseInt(150 * red);
                         // const green = 255 - red;
                         // console.log('red:', red, ', green:', green);
-                        contextstyle = `border: 2px solid rgb(0, 0, ${255 * red},0.75);`;
+                        contextstyle = `border: 2px solid rgb(${parseInt(255 * red)}, 0, 0,0.75);`;
                     }
                     dealProviousIndex++;
                 }

--- a/front/components/searchResult.vue
+++ b/front/components/searchResult.vue
@@ -3,160 +3,171 @@
     <v-navigation-drawer v-model="drawer" :mini-variant.sync="search" permanent class="searchList" id="box">
 
       <v-list-item class="searchTitle" style="padding:0px 10px 0px 10px;">
-        <v-btn icon hide-details @click.stop="search = !search" >
-            <v-icon hide-details>mdi-database-search-outline</v-icon>
-            <div id="searchCount">
-              <span style="font-size:3px;color:blue;" >{{visibleDealsIndex.length}}</span>
-            </div>
+        <v-btn icon hide-details @click.stop="search = !search">
+          <v-icon hide-details>mdi-database-search-outline</v-icon>
+          <div id="searchCount">
+            <span style="font-size:3px;color:blue;">{{ visibleDealsIndex.length }}</span>
+          </div>
         </v-btn>
         <v-list-item-title style="text-align: center;">
-          <v-form @submit.prevent="searchPlace">
-              <v-card :style="{display: 'flex',height:'100%',alignItems:'center',padding:'0px 0px 3px 10px'}">
-                  <v-text-field v-model="searchText" label="검색" hide-details :style="{display: 'flex', alignItems:'center'}" @input="onChangeText" />
-              </v-card>
+          <v-form @submit.prevent="searchName">
+            <v-card :style="{ display: 'flex', height: '100%', alignItems: 'center', padding: '0px 0px 3px 10px' }">
+              <v-text-field v-model="searchText" label="검색" hide-details :style="{ display: 'flex', alignItems: 'center' }"
+                @input="onChangeText" />
+            </v-card>
           </v-form>
         </v-list-item-title>
       </v-list-item>
 
       <v-divider></v-divider>
-      
+
       <v-list dense v-if="!search">
         <div style="min-height: 300px; max-height: 300px; overflow:auto;" class="dealListBox" id="dealListBox">
           <v-list-item v-for="i in searchDealList" v-if="dealList[i]" :key="i" link class="searchResult">
             <v-list-item-content>
-              <v-list-item-title style="font-weight:700">{{dealList[i].name}}</v-list-item-title>
+              <v-list-item-title style="font-weight:700">{{ dealList[i].name }}</v-list-item-title>
               <tr>
-                <td><span style="font-size:3px;color:blue;">{{dealList[i].house_type}} </span></td>
-                <td style="position:absolute; left:70px; bottom:9px;"><span style="font-size:3px;">{{dealList[i].area}}㎡</span></td>
-                <td style="position:absolute; left:170px; bottom:9px"><span style="font-size:3px;">{{amountToString(dealList[i].deal_amount)}}</span></td>
+                <td><span style="font-size:3px;color:blue;">{{ dealList[i].house_type }} </span></td>
+                <td style="position:absolute; left:70px; bottom:9px;"><span
+                    style="font-size:3px;">{{ dealList[i].area }}㎡</span></td>
+                <td style="position:absolute; left:170px; bottom:9px"><span
+                    style="font-size:3px;">{{ amountToString(dealList[i].deal_amount) }}</span></td>
               </tr>
             </v-list-item-content>
           </v-list-item>
         </div>
       </v-list>
-      
+
 
     </v-navigation-drawer>
-</div>
+  </div>
 
 
 </template>
 
 <script>
-  export default {
-    data () {
-      return {
-        drawer: true,
-        search: true,
-        mini:true,
-        searchText:'',
-        refresh:false,
-        searchDealList:[],
-      }
+export default {
+  data() {
+    return {
+      drawer: true,
+      search: true,
+      mini: true,
+      searchText: '',
+      refresh: false,
+      searchDealList: [],
+    }
+  },
+  mounted() {
+    window.addEventListener('wheel', this.onScroll);
+  },
+  beforeDestroy() {
+    window.addEventListener('wheel', this.onScroll);
+  },
+  computed: {
+    dealList() {
+      return this.$store.state.dealList.dealList;
     },
-    mounted(){
-        window.addEventListener('wheel',this.onScroll);
+    visibleDealsIndex() {
+      return this.$store.state.dealList.visibleDealsIndex;
     },
-    beforeDestroy(){
-        window.addEventListener('wheel',this.onScroll);
-    },
-    computed:{
-      dealList(){
-          return this.$store.state.dealList.dealList;
-      },
-      visibleDealsIndex(){
-          return this.$store.state.dealList.visibleDealsIndex;
-      },
-      refreshList(){
-          return this.$store.state.dealList.refreshList;
-      }
-    },
-    watch:{
-      refreshList(newVal,oldVal){
-          console.log("refreshList active")
-          this.searchDealList.splice(0)
-          if(!this.search){
-            let target=document.getElementById('dealListBox');
-            if(target.scrollHeight==target.clientHeight){
-              this.onScroll();
-            }else{
-              setTimeout(this.onScroll,100);
-            }
-          }
-      },
-      search(newVal,oldVal){
-        if(!newVal){
-          setTimeout(this.onScroll,100);
+    refreshList() {
+      return this.$store.state.dealList.refreshList;
+    }
+  },
+  watch: {
+    refreshList(newVal, oldVal) {
+      console.log("refreshList active")
+      this.searchDealList.splice(0)
+      if (!this.search) {
+        let target = document.getElementById('dealListBox');
+        if (target.scrollHeight == target.clientHeight) {
+          this.onScroll();
+        } else {
+          setTimeout(this.onScroll, 100);
         }
       }
     },
-    methods:{
-      async onScroll(){
-        let target=document.getElementById('dealListBox');
-        
-        if(target.scrollHeight-300<target.clientHeight+target.scrollTop){
-            if(this.visibleDealsIndex.length>this.searchDealList.length){
-                await this.addDealList();
-            }
-        }
-      },
-      async addDealList(){
-        let set=[];
-        let start=this.searchDealList.length;
-        let step=100;
-        let end = this.visibleDealsIndex.length;
-        console.log("end",end)
-
-        if(end<(start+step)){
-          step=end-start;
-        }
-        this.searchDealList=this.searchDealList.concat(this.visibleDealsIndex.slice(start,start+step));
-      
-        console.log("searchDealList:",this.searchDealList.length)
-      },
-      onChangeText(text){
-
-      },
-      amountToString(amount){
-            let result='';
-            let a =parseInt(amount/10000);
-            let b = amount%10000;
-            if(a){
-                result+=`${a}억`
-            }
-            if(b){
-              result+=`${b}만`
-            }
-            return result
+    search(newVal, oldVal) {
+      if (!newVal) {
+        setTimeout(this.onScroll, 100);
       }
     }
+  },
+  methods: {
+    searchName() {
+
+    },
+    async onScroll() {
+      let target = document.getElementById('dealListBox');
+
+      if (target.scrollHeight - 300 < target.clientHeight + target.scrollTop) {
+        if (this.visibleDealsIndex.length > this.searchDealList.length) {
+          await this.addDealList();
+        }
+      }
+    },
+    async addDealList() {
+      let set = [];
+      let start = this.searchDealList.length;
+      let step = 100;
+      let end = this.visibleDealsIndex.length;
+      console.log("end", end)
+
+      if (end < (start + step)) {
+        step = end - start;
+      }
+      this.searchDealList = this.searchDealList.concat(this.visibleDealsIndex.slice(start, start + step));
+
+      console.log("searchDealList:", this.searchDealList.length)
+    },
+    onChangeText(text) {
+
+    },
+    amountToString(amount) {
+      let result = '';
+      let a = parseInt(amount / 10000);
+      let b = amount % 10000;
+      if (a) {
+        result += `${a}억`
+      }
+      if (b) {
+        result += `${b}만`
+      }
+      return result
+    }
   }
+}
 </script>
 
 <style>
+.searchTitle {
+  background-color: #ffffffaa;
+}
 
-.searchTitle{
-    background-color: #ffffffaa;
+.searchResult {
+  scrollbar-width: none;
+  background-color: #ffffffaa;
 }
-.searchResult{
-    scrollbar-width: none;
-    background-color: #ffffffaa;
-}
-.invisible{
+
+.invisible {
   background-color: #00000000;
 }
-#searchCount{
-  position:absolute; 
-  align-items:'center';
-  left:1px; 
-  top:20px;
+
+#searchCount {
+  position: absolute;
+  align-items: 'center';
+  left: 1px;
+  top: 20px;
   width: 35px;
 }
-#box{
+
+#box {
   box-shadow: 0px 3px 1px -2px rgb(0 0 0 / 20%), 0px 2px 2px 0px rgb(0 0 0 / 14%), 0px 1px 5px 0px rgb(0 0 0 / 12%);
   border-radius: 8px;
 }
+
 #dealListBox::-webkit-scrollbar {
-    display: none; /* Chrome, Safari, Opera*/
+  display: none;
+  /* Chrome, Safari, Opera*/
 }
 </style>

--- a/front/pages/index.vue
+++ b/front/pages/index.vue
@@ -16,7 +16,7 @@
         <nav class="navBar">
             <v-toolbar dark color="green">
                 <v-toolbar-title>
-                    <nuxt-link to="/">NodeBird</nuxt-link>
+                    <nuxt-link to="/">지역 검색</nuxt-link>
                 </v-toolbar-title>
                 <v-toolbar-items style="margin-left:20px">
                     <v-form @submit.prevent="searchPlace">
@@ -28,10 +28,10 @@
                 </v-toolbar-items>
                 <v-spacer />
                 <v-toolbar-items>
-                    <v-btn text nuxt to="/profile">
+                    <v-btn text nuxt to="">
                         <div>프로필</div>
                     </v-btn>
-                    <v-btn text nuxt to="/signup">
+                    <v-btn text nuxt to="">
                         <div>회원가입</div>
                     </v-btn>
                 </v-toolbar-items>

--- a/front/store/graph.js
+++ b/front/store/graph.js
@@ -1,0 +1,25 @@
+export const state = () => ({
+    tradingVolumList: {},
+})
+
+export const mutations = {
+    setTradingVolum(state, payload) {
+        //delete state.tradingVolumList;
+        state.tradingVolumList = payload;
+        console.log("***", state.tradingVolumList);
+    }
+}
+
+export const actions = {
+    async setTradingVolum({ commit }, payload) {
+        await this.$axios.post('http://127.0.0.1:7000/traingVolum', {
+            mapState: payload
+        })
+            .then(async (res) => {
+                commit('setTradingVolum', res.data.data)
+            })
+            .catch((error) => {
+                console.error(error);
+            })
+    }
+}

--- a/front/store/graph.js
+++ b/front/store/graph.js
@@ -1,12 +1,19 @@
 export const state = () => ({
     tradingVolumList: {},
+    amountAVGList: {},
+    changeType: 0,
 })
 
 export const mutations = {
     setTradingVolum(state, payload) {
-        //delete state.tradingVolumList;
         state.tradingVolumList = payload;
-        console.log("***", state.tradingVolumList);
+    },
+    setAmountAVGList(state, payload) {
+        state.amountAVGList = payload;
+    },
+    setChangeType(state, payload) {
+        state.changeType = (state.changeType + 1) % 2;
+        console.log(state.changeType);
     }
 }
 
@@ -21,5 +28,19 @@ export const actions = {
             .catch((error) => {
                 console.error(error);
             })
+    },
+    async setAmountAVGList({ commit }, payload) {
+        await this.$axios.post('http://127.0.0.1:7000/amountAVG', {
+            mapState: payload
+        })
+            .then(async (res) => {
+                commit('setAmountAVGList', res.data.data)
+            })
+            .catch((error) => {
+                console.error(error);
+            })
+    },
+    async setChangeType({ commit }, payload) {
+        commit('setChangeType')
     }
 }


### PR DESCRIPTION
### 1. 월별 거래량을 그래프로 시각화하여 정보 제공
- 각 동 별 정보를 선형그래프로 시각화하여 제공합니다.
- 설정정보(house_type,기간)에 따라 시각화되는 정보가 정제되어 표시됩니다.

### 2. 월별 거래매물의 평당 거래단가 정보를 그래프로 시각화하여 정보 제공
- 각 동 별 정보를 선형그래프로 시각화하여 제공합니다.
- 설정정보(house_type,기간)에 따라 시각화되는 정보가 정제되어 표시됩니다.

그래프 아이콘 내에서 표시되는 두개의 시각화 정보가 전환 아이콘을 통해 교환됩니다.
불필요한 정보 요청을 최소화 하기 위하여 각 정보는 해당 그래프가 활성화 되었을 경우에 정보를 요청합니다.