### PR TITLE
fix:cors 주소 수정

### DIFF
--- a/back/src/infrastructure/express/index.js
+++ b/back/src/infrastructure/express/index.js
@@ -26,7 +26,7 @@ module.exports = async (port = 7000, options) => {
         app.use(hpp());
         app.use(morgan('combined'));
         app.use(cors({
-            origin: 'http://http://ec2-52-21-184-141.compute-1.amazonaws.com',
+            origin: 'http://ec2-52-21-184-141.compute-1.amazonaws.com',
             credentials: true
         }));
     } else {


### PR DESCRIPTION
express의 cors 허용 주소 'http://http://ec2-52-21-184-141.compute-1.amazonaws.com' => 'http://ec2-52-21-184-141.compute-1.amazonaws.com'로 수정(주소 오타 정정)